### PR TITLE
Add Repository information to NuSpec

### DIFF
--- a/Shuttle.Core.Cron/.build/package.nuspec
+++ b/Shuttle.Core.Cron/.build/package.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package >
+<package>
 	<metadata>
 		<id>Shuttle.Core.Cron</id>
 		<version>{semver}</version>
@@ -8,14 +8,15 @@
 		<licenseUrl>https://github.com/shuttle/Shuttle.Core.Cron/raw/master/LICENSE</licenseUrl>
 		<projectUrl>https://github.com/shuttle/Shuttle.Core.Cron</projectUrl>
 		<iconUrl>https://raw.githubusercontent.com/Shuttle/Shuttle.Core.Cron/master/.media/logo.png</iconUrl>
+		<repository type="git" url="https://github.com/Shuttle/Shuttle.Core.Cron.git" />
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<description>Cron expression parsing.</description>
 		<releaseNotes/>
 		<copyright>Copyright (c) {year}, Eben Roux</copyright>
 		<tags>shuttle cron scheduling</tags>
-    <dependencies>
-      <dependency id="Shuttle.Core.Contract" version="{Shuttle.Core.Contract-version}" />
-      <dependency id="Shuttle.Core.Specification" version="{Shuttle.Core.Specification-version}" />
-    </dependencies>
+		<dependencies>
+			<dependency id="Shuttle.Core.Contract" version="{Shuttle.Core.Contract-version}" />
+			<dependency id="Shuttle.Core.Specification" version="{Shuttle.Core.Specification-version}" />
+		</dependencies>
 	</metadata>
 </package>


### PR DESCRIPTION
Nuget provides elements to specify where the source code repository is for a nuget package, by specifying a [repository element](https://github.com/NuGet/NuGet.Client/blob/dev/src/NuGet.Core/NuGet.Packaging/compiler/resources/nuspec.xsd#L67).

It would be great if we had this information straight into the .nuspec, which would allow tooling such as [Renovate](https://renovatebot.com/) to fetch detailed information about releases (what specifically has been fixed [sample](https://github.com/tomkerkhove/promitor/pull/101)).

This adds the repository location to the nuspec.

Kudos to @samneirinck to provide .NET support to Renovate.